### PR TITLE
Habitat plan

### DIFF
--- a/habitat/config/config.json
+++ b/habitat/config/config.json
@@ -1,0 +1,9 @@
+{
+ "listen": {
+   "address": "{{cfg.listen.address}}",
+   "port": {{cfg.listen.port}}
+ },
+ "storage": {
+   "path": "{{cfg.storage.path}}"
+ }
+}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -4,5 +4,3 @@ port = 8228
 
 [storage]
 path = "/srv/leverage/leverage.sqlite"
-
-[services.core.nginx.leverage]

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,8 @@
+[listen]
+address = "0.0.0.0"
+port = 8228
+
+[storage]
+path = "/srv/leverage/leverage.sqlite"
+
+[services.core.nginx.leverage]

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,0 +1,7 @@
+#!/bin/sh
+ln -sf {{pkg.path}}/package.json {{pkg.svc_var_path}}
+ln -sf {{pkg.path}}/app.js {{pkg.svc_var_path}}
+ln -sf {{pkg.path}}/node_modules {{pkg.svc_var_path}}
+ln -sf {{pkg.path}}/lib {{pkg.svc_var_path}}
+ln -sf {{pkg.path}}/controllers {{pkg.svc_var_path}}
+ln -sf {{pkg.svc_config_path}}/config.json {{pkg.svc_var_path}}

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd {{pkg.svc_var_path}}
+exec node app.js 2>&1

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,5 +1,5 @@
-pkg_origin=leverage-api
-pkg_name=leverage
+pkg_origin=leverage
+pkg_name=leverage-api
 pkg_version=0.1.0
 pkg_maintainer="Chris Alfano <chris@codeforphilly.org>"
 pkg_license=(MIT)

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,57 @@
+pkg_origin=leverage-api
+pkg_name=leverage
+pkg_version=0.1.0
+pkg_maintainer="Chris Alfano <chris@codeforphilly.org>"
+pkg_license=(MIT)
+pkg_upstream_url=https://github.com/Lever-age/api
+pkg_source=leverage-api.tar.gz
+pkg_deps=(bochener/node)
+pkg_expose=(8228)
+pkg_build_deps=(core/coreutils)
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  # The `/usr/bin/env` path is hardcoded, so we'll add a symlink if needed.
+  # We can't do fix_interpreter here without adding a coreutils runtime dep.
+  if [[ ! -r /usr/bin/env ]]; then
+    ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+    _clean_env=true
+  fi
+}
+
+do_build() {
+  cp -vr $PLAN_CONTEXT/../* $HAB_CACHE_SRC_PATH/$pkg_dirname
+
+  cd $HAB_CACHE_SRC_PATH/$pkg_dirname
+  npm install
+}
+
+do_install() {
+  # Our source files were copied over to HAB_CACHE_SRC_PATH/$pkg_dirname in do_build(),
+  # and now they need to be copied from that directory into the root directory of our package
+  # through the use of the pkg_prefix variable.
+
+  cp -v package.json ${pkg_prefix}
+  cp -v app.js ${pkg_prefix}
+  cp -vr controllers ${pkg_prefix}
+  cp -vr lib ${pkg_prefix}
+  cp -r node_modules ${pkg_prefix}
+}
+
+do_end() {
+  # Clean up the `env` link, if we set it up.
+  if [[ -n "$_clean_env" ]]; then
+    rm -fv /usr/bin/env
+  fi
+}


### PR DESCRIPTION
Work-in-progress to make `leverage-api` deployable via habitat

This plan will:
- [X] Include node_modules in build
- [X] Expose `leverage-api` is a runnable habitat service
- [ ] Accept all configuration via habitat