### PR TITLE
Ensure all required python modules included in requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Initially copied from Illinois Sunshine.
 
 * Python 3.4
 * PostgreSQL 9.4 +
+* MySQL client libraries + development headers
+  + Ubuntu Xenial: `libmysqlclient-dev` package
+  + Debian Stretch: `libmariadbclient-dev` package
+  + Fedora 26/CentOS 7: `mariadb-devel` package
+  + OpenSUSE Leap 42.3: `libmysqlclient-devel` package
+  + OS X Sierra: `mysql` homebrew formula
 
 **Install app requirements**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,7 @@ Jinja2==2.7.3
 python-dateutil==2.2
 pytz==2014.10
 SQLAlchemy==1.0.6
-
-# Below breaks, install python3-mysqldb
-#mysqlclient==1.3.12
+mysqlclient==1.3.12
 
 # Optional
 # sqlalchemy_schemadisplay==1.3


### PR DESCRIPTION
mysqlclient would cause `pip install` to fail on machines which did not have mysql development headers and utilites installed. Adding a note to the README about this OS level dependency should help people avoid problems with builds in the future.